### PR TITLE
Feat/m3 telemetry schema scrubber beacons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .DS_Store
 tests/e2e/playwright-report
 infra/.env
+logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Treat failing E2E as a product signal: fix or document flakiness with a ticket.
   "request_id": "uuid-optional",
   "route": "/client/route-or-api/endpoint",
   "status": 500,
-  "error_code": "API_ERROR",
+  "error_code": "HTTP_ERROR",
   "error": "message or scrubbed stack"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Every request gets a unique `x-request-id` that flows through:
 3. **Telemetry events** include the request ID for correlation
 4. **E2E tests** verify end-to-end traceability
 
+### Automatic Telemetry Beacons
+
+The web app automatically sends telemetry for failed requests:
+- **Non-OK HTTP responses** (4xx/5xx) trigger telemetry events
+- **Network errors** are captured and reported
+- Uses **navigator.sendBeacon** for reliability (fallback to fetch)
+- **Non-blocking** - never affects user experience
+- **Error categorization** - HTTP_ERROR vs NETWORK_ERROR
+
 ### Telemetry Schema
 
 The telemetry package provides **Zod schema validation** and **data scrubbing** for safe logging:

--- a/README.md
+++ b/README.md
@@ -143,12 +143,19 @@ This works in both dev and preview modes, eliminating CORS issues.
 
 ### Playwright Testing
 
-E2E tests demonstrate complete request traceability:
+E2E tests provide comprehensive validation with two focused test scenarios:
 
+**Test 1: End-to-End Request Correlation**
 1. **Trigger error** by clicking "Trigger API Error" button
 2. **Capture request ID** from `window.__lastReqId`
 3. **Verify telemetry** via `/debug/last-event` endpoint
 4. **Assert correlation** between UI request and logged telemetry
+
+**Test 2: API Security and Data Scrubbing**
+1. **Send realistic sensitive data** to telemetry API
+2. **Verify data scrubbing** - emails redacted, tokens removed
+3. **Assert normal data preserved** - no over-scrubbing
+4. **Validate security contract** - no sensitive data leakage
 
 Test artifacts on failure:
 - **Screenshots** of the failing state

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -87,7 +87,7 @@ Returns the last telemetry event received by the server. Only available in non-p
   "route": "/api/fail",
   "status": 500,
   "request_id": "123e4567-e89b-12d3-a456-426614174000",
-  "error_code": "API_ERROR",
+  "error_code": "HTTP_ERROR",
   "error": "500 Internal Server Error"
 }
 ```

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -1,5 +1,7 @@
 import express, { Request, Response, NextFunction, Express } from 'express';
-import { initTelemetry, type TelemetryEvent } from 'telemetry';
+import { initTelemetry, TelemetryEventSchema, scrub, type TelemetryEvent } from 'telemetry';
+import { writeFileSync, existsSync, mkdirSync, appendFileSync } from 'fs';
+import { join, dirname } from 'path';
 
 const app: Express = express();
 const PORT = process.env.PORT || 3000;
@@ -39,6 +41,22 @@ app.use(correlateRequests);
 // In-memory storage for last telemetry event (dev/test only)
 let lastTelemetryEvent: TelemetryEvent | null = null;
 
+// Ensure logs directory exists
+function ensureLogsDir(): void {
+  const logsDir = join(process.cwd(), 'logs');
+  if (!existsSync(logsDir)) {
+    mkdirSync(logsDir, { recursive: true });
+  }
+}
+
+// Log telemetry event to NDJSON file
+function logTelemetryEvent(event: TelemetryEvent): void {
+  ensureLogsDir();
+  const logPath = join(process.cwd(), 'logs', 'telemetry.ndjson');
+  const logLine = JSON.stringify(event) + '\n';
+  appendFileSync(logPath, logLine, 'utf8');
+}
+
 // Health check endpoint
 app.get('/healthz', (req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });
@@ -62,37 +80,67 @@ app.get('/debug/last-event', (req: Request, res: Response) => {
   res.json(lastTelemetryEvent);
 });
 
+// Debug endpoint to get last accepted telemetry event from memory
+app.get('/debug/telemetry/last', (req: Request, res: Response) => {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  
+  if (!lastTelemetryEvent) {
+    return res.status(404).json({ error: 'No telemetry events received yet' });
+  }
+  
+  res.json(lastTelemetryEvent);
+});
+
 // Telemetry endpoint
 app.post('/telemetry', (req: Request, res: Response) => {
-  const event = req.body as Partial<TelemetryEvent>;
+  const requestId = res.locals.requestId;
   
-  // Basic validation
-  if (!event.ts || !event.level || !event.env || !event.release) {
+  try {
+    // Validate request body against TelemetryEventSchema
+    const validationResult = TelemetryEventSchema.safeParse(req.body);
+    
+    if (!validationResult.success) {
+      res.setHeader('x-request-id', requestId);
+      return res.status(400).json({ 
+        error: 'VALIDATION_ERROR',
+        message: 'Invalid telemetry event structure',
+        details: validationResult.error.issues
+      });
+    }
+    
+    let event = validationResult.data;
+    
+    // Ensure request_id from correlation middleware; set if missing
+    if (!event.request_id) {
+      event = { ...event, request_id: requestId };
+    }
+    
+    // Scrub sensitive data in details field
+    if (event.details) {
+      event = { ...event, details: scrub(event.details) as Record<string, unknown> };
+    }
+    
+    // Store last event for debug endpoint (dev/test only)
+    if (process.env.NODE_ENV !== 'production') {
+      lastTelemetryEvent = event;
+    }
+    
+    // Log to NDJSON file
+    logTelemetryEvent(event);
+    
+    // Also log to console with request_id
+    console.log(JSON.stringify(event));
+    
+    res.status(204).send();
+  } catch (error) {
+    res.setHeader('x-request-id', requestId);
     return res.status(400).json({ 
-      error: 'Missing required fields: ts, level, env, release' 
+      error: 'PROCESSING_ERROR',
+      message: 'Failed to process telemetry event'
     });
   }
-  
-  // Add request_id if missing
-  const telemetryEvent: TelemetryEvent = {
-    ...event,
-    request_id: event.request_id || res.locals.requestId
-  } as TelemetryEvent;
-  
-  // Store last event for debug endpoint (dev/test only)
-  if (process.env.NODE_ENV !== 'production') {
-    lastTelemetryEvent = telemetryEvent;
-  }
-  
-  // Log the event with request_id
-  const logEntry = {
-    ...telemetryEvent,
-    request_id: res.locals.requestId
-  };
-  
-  console.log(JSON.stringify(logEntry));
-  
-  res.status(204).send();
 });
 
 if (process.env.NODE_ENV !== 'test') {

--- a/docs/ai/runs/2025-08-19T00-22-11Z-m3-p1-telemetry-schema-scrubber-tests.md
+++ b/docs/ai/runs/2025-08-19T00-22-11Z-m3-p1-telemetry-schema-scrubber-tests.md
@@ -1,0 +1,41 @@
+---
+date: "2025-08-19T00-22-11Z"
+tool: "Claude Code"
+title: "M3/P1 telemetry schema + scrubber + tests"
+branch: "feat/m3-telemetry-schema-scrubber-beacons"
+base_commit: "912e907"
+---
+
+# Prompt
+```
+Task (packages/telemetry only)
+- Add "zod" dep; devDeps "vitest", "@types/node" if missing.
+- Export TelemetryEventSchema (zod) with fields:
+  { ts:number, level:'info'|'warn'|'error', env:string, release:string,
+    route?:string, status?:number, request_id?:string,
+    error_code?:string, error?:string, details?:Record<string, unknown> }
+- Export type TelemetryEvent.
+- Implement scrub(value) with:
+  - email redaction (***@domain),
+  - token-ish redaction ([REDACTED]) for long hex/base64-like,
+  - redact values for keys containing password/secret/token/auth/key,
+  - truncate long strings >500 chars.
+  - handle arrays, circular refs.
+- Add vitest tests for scrub().
+- Keep TS strict, ESM exports intact.
+
+Output:
+- Diffs (unified) for only packages/telemetry/**.
+- Commands for me (pnpm add …).
+- One commit message:
+  feat(telemetry): zod schema + scrubber + tests [AI-assisted-by: Claude Code]
+```
+
+# Assistant output (optional)
+```
+
+```
+
+# Notes
+- [ ] Human-reviewed
+- [ ] Tested in CI

--- a/docs/ai/runs/2025-08-19T00-39-37Z-m3-p2-api-telemetry-with-validation-scrub-debug-endpoint.md
+++ b/docs/ai/runs/2025-08-19T00-39-37Z-m3-p2-api-telemetry-with-validation-scrub-debug-endpoint.md
@@ -1,0 +1,34 @@
+---
+date: "2025-08-19T00-39-37Z"
+tool: "Claude Code"
+title: "M3/P2 API /telemetry with validation/scrub + debug endpoint"
+branch: "feat/m3-telemetry-schema-scrubber-beacons"
+base_commit: "09c911a"
+---
+
+# Prompt
+```
+Task (apps/api)
+- In POST /telemetry:
+  - Validate body via packages/telemetry TelemetryEventSchema.
+  - Ensure request_id from correlation middleware; if missing, set.
+  - Scrub details; append one-line JSON to logs/telemetry.ndjson; 204 on success.
+  - 400 with a small code + echo x-request-id on validation errors.
+- Add GET /debug/telemetry/last returning the last accepted (scrubbed) event from memory.
+- Ensure logs/ is gitignored if not already.
+
+Output:
+- Diffs for apps/api/** (and .gitignore if needed).
+- Any commands for me (none expected).
+- Commit message:
+  feat(api): /telemetry validates/scrubs/logs; /debug/telemetry/last [AI-assisted-by: Claude Code]
+```
+
+# Assistant output (optional)
+```
+
+```
+
+# Notes
+- [ ] Human-reviewed
+- [ ] Tested in CI

--- a/docs/ai/runs/2025-08-19T00-47-53Z-m3-p3-web-error-beacon-via-fetch-wrapper.md
+++ b/docs/ai/runs/2025-08-19T00-47-53Z-m3-p3-web-error-beacon-via-fetch-wrapper.md
@@ -1,0 +1,31 @@
+---
+date: "2025-08-19T00-47-53Z"
+tool: "Claude Code"
+title: "M3/P3 web error beacon via fetch-wrapper"
+branch: "feat/m3-telemetry-schema-scrubber-beacons"
+base_commit: "0c5e92c"
+---
+
+# Prompt
+```
+Task (apps/web)
+- In src/lib/fetch-wrapper.ts:
+  - On non-OK responses, construct a TelemetryEvent using the same request_id used on the request, and send to /telemetry.
+  - Prefer navigator.sendBeacon(JSON), fallback to fetch POST.
+  - Non-blocking, ignore beacon failures.
+- Ensure imports from telemetry are type-only where appropriate.
+
+Output:
+- Diffs for apps/web/** only.
+- Commit message:
+  feat(web): send telemetry beacon on non-OK responses [AI-assisted-by: Claude Code]
+```
+
+# Assistant output (optional)
+```
+
+```
+
+# Notes
+- [ ] Human-reviewed
+- [ ] Tested in CI

--- a/docs/ai/runs/2025-08-19T01-03-10Z-m3-p4-e2e-verify-request-id-and-scrubbing.md
+++ b/docs/ai/runs/2025-08-19T01-03-10Z-m3-p4-e2e-verify-request-id-and-scrubbing.md
@@ -1,0 +1,34 @@
+---
+date: "2025-08-19T01-03-10Z"
+tool: "Claude Code"
+title: "M3/P4 E2E: verify request_id and scrubbing"
+branch: "feat/m3-telemetry-schema-scrubber-beacons"
+base_commit: "aed707a"
+---
+
+# Prompt
+```
+Task (tests/e2e)
+- Add/extend a Playwright test that:
+  1) Triggers a failing request from the UI (use existing fail action if present; otherwise add the minimal UI trigger and update the test accordingly).
+  2) Calls /debug/telemetry/last and asserts:
+     - request_id matches the one from the failed request,
+     - level === 'error',
+     - route/status present,
+     - no raw emails/tokens (scrubbed).
+- Keep webServer settings (USE_DEV_SERVER toggle) working.
+
+Output:
+- Diffs for tests/e2e/** (and minimal UI diff if needed).
+- Commit message:
+  test(e2e): prove request_id correlation + scrubbing via /debug/telemetry/last [AI-assisted-by: Claude Code]
+```
+
+# Assistant output (optional)
+```
+
+```
+
+# Notes
+- [ ] Human-reviewed
+- [ ] Tested in CI

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -80,7 +80,7 @@ async function apiCall(url: string, requestId: string) {
         route: new URL(url).pathname,
         status: response.status,
         request_id: requestId,
-        error_code: 'API_ERROR',
+        error_code: 'HTTP_ERROR',
         error: `${response.status} ${response.statusText}`
       });
     }

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -7,7 +7,8 @@ Framework-agnostic TypeScript utilities for structured event emission and teleme
 - **Framework-agnostic**: Works with any JavaScript/TypeScript runtime
 - **ESM-first**: Modern ES modules with proper exports mapping
 - **Type-safe**: Full TypeScript support with strict typing
-- **Zero dependencies**: Lightweight with no external runtime dependencies
+- **Schema validation**: Zod-based schema for runtime validation
+- **Data scrubbing**: Built-in sensitive data redaction utilities
 - **Structured schema**: Consistent event format across applications
 - **Request correlation**: Built-in support for request ID tracking
 
@@ -26,7 +27,7 @@ pnpm add telemetry
 ### Basic Setup
 
 ```typescript
-import { initTelemetry, emitEvent, type TelemetryEvent } from 'telemetry';
+import { initTelemetry, emitEvent, scrub, TelemetryEventSchema, type TelemetryEvent } from 'telemetry';
 
 // Initialize once at application startup
 initTelemetry({
@@ -142,13 +143,37 @@ app.use((req, res, next) => {
 
 ## API Reference
 
-### Types
+### Schema and Types
+
+#### `TelemetryEventSchema`
+
+Zod schema for runtime validation and type inference:
+
+```typescript
+import { z } from 'zod';
+
+export const TelemetryEventSchema = z.object({
+  ts: z.number(),
+  level: z.enum(['info', 'warn', 'error']),
+  env: z.string(),
+  release: z.string(),
+  route: z.string().optional(),
+  status: z.number().optional(),
+  request_id: z.string().optional(),
+  error_code: z.string().optional(),
+  error: z.string().optional(),
+  details: z.record(z.unknown()).optional(),
+});
+```
 
 #### `TelemetryEvent`
 
-The core telemetry event interface:
+TypeScript type inferred from the schema:
 
 ```typescript
+export type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
+
+// Equivalent to:
 interface TelemetryEvent {
   ts: number;                           // Unix timestamp in milliseconds
   level: 'info' | 'warn' | 'error';    // Event severity level
@@ -218,6 +243,60 @@ emitEvent({
   error_code: 'VALIDATION_FAILED',
   error: 'Invalid user input',
   details: { field: 'email', value: 'invalid-email' }
+});
+```
+
+#### `scrub(value: unknown): unknown`
+
+Scrubs sensitive data from values for safe logging. Handles nested objects, arrays, and circular references.
+
+**Features:**
+- **Email redaction**: `user@example.com` → `***@example.com`
+- **Token-like redaction**: Long hex/base64 strings → `[REDACTED]`
+- **Sensitive key redaction**: Keys containing `password`, `secret`, `token`, `auth`, `key` → `[REDACTED]`
+- **String truncation**: Strings >500 chars → truncated with `...`
+- **Circular reference protection**: Circular refs → `[CIRCULAR]`
+- **Depth limiting**: Prevents infinite recursion → `[MAX_DEPTH]`
+
+**Parameters:**
+- `value` - Any value to scrub (objects, arrays, primitives)
+
+**Returns:**
+- Scrubbed copy of the input value
+
+**Examples:**
+```typescript
+// Email redaction
+scrub('Contact support@company.com') // → 'Contact ***@company.com'
+
+// Sensitive key redaction  
+scrub({ username: 'john', password: 'secret123' })
+// → { username: 'john', password: '[REDACTED]' }
+
+// Token redaction
+scrub('Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...')
+// → '[REDACTED]'
+
+// Complex object scrubbing
+const userData = {
+  profile: { email: 'user@company.com', apiKey: 'sk-abc123...' },
+  logs: ['Error for admin@company.com', 'Success']
+};
+
+scrub(userData)
+// → {
+//     profile: { email: '***@company.com', apiKey: '[REDACTED]' },
+//     logs: ['Error for ***@company.com', 'Success']
+//   }
+
+// Use with telemetry
+emitEvent({
+  ts: Date.now(),
+  level: 'error',
+  env: 'production', 
+  release: 'v1.2.3',
+  error: 'Validation failed',
+  details: scrub(sensitiveUserInput) // Safely scrub before logging
 });
 ```
 
@@ -309,6 +388,12 @@ pnpm build
 
 # Watch mode for development
 pnpm dev
+
+# Run tests
+pnpm test
+
+# Run tests in watch mode
+pnpm test:watch
 ```
 
 ### Package Structure
@@ -316,12 +401,14 @@ pnpm dev
 ```
 packages/telemetry/
 ├── src/
-│   └── index.ts          # Main implementation
+│   ├── index.ts          # Main implementation
+│   └── scrub.test.ts     # Vitest test suite
 ├── dist/                 # Built output (generated)
 │   ├── index.js          # Compiled JavaScript
 │   └── index.d.ts        # Type definitions
 ├── package.json          # Package configuration
 ├── tsconfig.json         # TypeScript configuration
+├── vitest.config.ts      # Vitest configuration
 └── README.md            # This file
 ```
 
@@ -396,11 +483,26 @@ app.post('/telemetry', (req, res) => {
 
 ### Testing
 
-The telemetry package is designed to be easily testable:
+The telemetry package includes comprehensive tests using Vitest:
 
 ```typescript
-// Mock console.log to capture telemetry events in tests
-const mockLog = jest.spyOn(console, 'log').mockImplementation();
+// Built-in scrub function tests
+import { describe, it, expect } from 'vitest';
+import { scrub } from 'telemetry';
+
+describe('scrub', () => {
+  it('should redact email addresses', () => {
+    expect(scrub('user@example.com')).toBe('***@example.com');
+  });
+  
+  it('should redact sensitive keys', () => {
+    const result = scrub({ password: 'secret', name: 'john' });
+    expect(result).toEqual({ password: '[REDACTED]', name: 'john' });
+  });
+});
+
+// Testing telemetry emission
+const mockLog = vi.spyOn(console, 'log').mockImplementation();
 
 initTelemetry({
   env: 'test',

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -15,9 +15,16 @@
   ],
   "scripts": {
     "build": "tsc -p .",
-    "dev": "tsc -p . --watch"
+    "dev": "tsc -p . --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "typescript": "^5.9.2"
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "zod": "^3.24.1"
   }
 }

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,15 +1,19 @@
-export interface TelemetryEvent {
-  ts: number;
-  level: 'info' | 'warn' | 'error';
-  env: string;
-  release: string;
-  route?: string;
-  status?: number;
-  request_id?: string;
-  error_code?: string;
-  error?: string;
-  details?: Record<string, unknown>;
-}
+import { z } from 'zod';
+
+export const TelemetryEventSchema = z.object({
+  ts: z.number(),
+  level: z.enum(['info', 'warn', 'error']),
+  env: z.string(),
+  release: z.string(),
+  route: z.string().optional(),
+  status: z.number().optional(),
+  request_id: z.string().optional(),
+  error_code: z.string().optional(),
+  error: z.string().optional(),
+  details: z.record(z.unknown()).optional(),
+});
+
+export type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 interface TelemetryOptions {
   env: string;
@@ -21,6 +25,84 @@ let telemetryConfig: TelemetryOptions | null = null;
 
 export function initTelemetry(opts: TelemetryOptions): void {
   telemetryConfig = { ...opts };
+}
+
+/**
+ * Scrubs sensitive data from values for safe logging
+ */
+export function scrub(value: unknown): unknown {
+  const visited = new WeakSet<object>();
+  
+  function scrubValue(val: unknown, depth = 0): unknown {
+    // Prevent infinite recursion
+    if (depth > 10) return '[MAX_DEPTH]';
+    
+    // Handle null/undefined
+    if (val === null || val === undefined) return val;
+    
+    // Handle primitives
+    if (typeof val === 'string') {
+      // Email redaction: user@domain.com -> ***@domain.com
+      let processedVal = val.replace(/\b[\w._%+-]+@([\w.-]+\.[A-Z]{2,})\b/gi, '***@$1');
+      
+      // Token-like redaction: long hex/base64 strings (but not simple repeated chars)
+      if (processedVal.length > 20 && 
+          /^[A-Za-z0-9+/=_-]+$/.test(processedVal) &&
+          !/^(.)\1*$/.test(processedVal)) { // Not just repeated single character
+        return '[REDACTED]';
+      }
+      
+      // Truncate long strings
+      if (processedVal.length > 500) {
+        return processedVal.substring(0, 497) + '...';
+      }
+      
+      return processedVal;
+    }
+    
+    if (typeof val === 'number' || typeof val === 'boolean') {
+      return val;
+    }
+    
+    // Handle arrays
+    if (Array.isArray(val)) {
+      if (visited.has(val)) return '[CIRCULAR]';
+      visited.add(val);
+      const result = val.map(item => scrubValue(item, depth + 1));
+      visited.delete(val);
+      return result;
+    }
+    
+    // Handle objects
+    if (typeof val === 'object') {
+      if (visited.has(val)) return '[CIRCULAR]';
+      visited.add(val);
+      
+      const result: Record<string, unknown> = {};
+      
+      for (const [key, objVal] of Object.entries(val)) {
+        const lowerKey = key.toLowerCase();
+        
+        // Redact sensitive keys
+        if (lowerKey.includes('password') || 
+            lowerKey.includes('secret') || 
+            lowerKey.includes('token') || 
+            lowerKey.includes('auth') || 
+            lowerKey.includes('key')) {
+          result[key] = '[REDACTED]';
+        } else {
+          result[key] = scrubValue(objVal, depth + 1);
+        }
+      }
+      
+      visited.delete(val);
+      return result;
+    }
+    
+    return val;
+  }
+  
+  return scrubValue(value);
 }
 
 export function emitEvent(evt: TelemetryEvent): void {

--- a/packages/telemetry/src/scrub.test.ts
+++ b/packages/telemetry/src/scrub.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { scrub } from './index.js';
+
+describe('scrub', () => {
+  describe('email redaction', () => {
+    it('should redact email addresses', () => {
+      expect(scrub('user@example.com')).toBe('***@example.com');
+      expect(scrub('test.email+tag@domain.co.uk')).toBe('***@domain.co.uk');
+      expect(scrub('Contact us at support@company.com for help')).toBe('Contact us at ***@company.com for help');
+    });
+  });
+
+  describe('token-like redaction', () => {
+    it('should redact long hex/base64-like strings', () => {
+      const longHex = 'a1b2c3d4e5f67890abcdef1234567890abcdef12';
+      expect(scrub(longHex)).toBe('[REDACTED]');
+      
+      const base64Token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+      expect(scrub(base64Token)).toBe('[REDACTED]');
+      
+      const apiKey = 'sk-1234567890abcdef1234567890abcdef';
+      expect(scrub(apiKey)).toBe('[REDACTED]');
+    });
+
+    it('should not redact short strings', () => {
+      expect(scrub('short123')).toBe('short123');
+      expect(scrub('abc')).toBe('abc');
+    });
+  });
+
+  describe('sensitive key redaction', () => {
+    it('should redact values for keys containing password/secret/token/auth/key', () => {
+      const obj = {
+        password: 'secret123',
+        apiKey: 'abc123',
+        authToken: 'xyz789',
+        user_secret: 'hidden',
+        normalField: 'visible',
+        PASSWORD: 'case-insensitive',
+      };
+
+      const result = scrub(obj) as Record<string, unknown>;
+      expect(result.password).toBe('[REDACTED]');
+      expect(result.apiKey).toBe('[REDACTED]');
+      expect(result.authToken).toBe('[REDACTED]');
+      expect(result.user_secret).toBe('[REDACTED]');
+      expect(result.normalField).toBe('visible');
+      expect(result.PASSWORD).toBe('[REDACTED]');
+    });
+  });
+
+  describe('string truncation', () => {
+    it('should truncate strings longer than 500 characters', () => {
+      const longString = 'a'.repeat(600);
+      const result = scrub(longString) as string;
+      expect(result).toBe('a'.repeat(497) + '...');
+      expect(result.length).toBe(500);
+    });
+
+    it('should not truncate strings 500 characters or less', () => {
+      const okString = 'a'.repeat(500);
+      expect(scrub(okString)).toBe(okString);
+    });
+  });
+
+  describe('array handling', () => {
+    it('should scrub array elements', () => {
+      const arr = ['user@example.com', { password: 'secret' }, 'normal'];
+      const result = scrub(arr) as unknown[];
+      
+      expect(result[0]).toBe('***@example.com');
+      expect((result[1] as Record<string, unknown>).password).toBe('[REDACTED]');
+      expect(result[2]).toBe('normal');
+    });
+  });
+
+  describe('circular reference handling', () => {
+    it('should handle circular references', () => {
+      const obj: Record<string, unknown> = { name: 'test' };
+      obj.self = obj;
+      
+      const result = scrub(obj) as Record<string, unknown>;
+      expect(result.name).toBe('test');
+      expect(result.self).toBe('[CIRCULAR]');
+    });
+  });
+
+  describe('depth limiting', () => {
+    it('should limit recursion depth', () => {
+      let deepObj: Record<string, unknown> = { value: 'deep' };
+      
+      // Create object 15 levels deep
+      for (let i = 0; i < 15; i++) {
+        deepObj = { nested: deepObj };
+      }
+      
+      const result = scrub(deepObj);
+      // Should not throw and should contain MAX_DEPTH somewhere in the structure
+      expect(JSON.stringify(result)).toContain('[MAX_DEPTH]');
+    });
+  });
+
+  describe('primitive values', () => {
+    it('should handle null and undefined', () => {
+      expect(scrub(null)).toBe(null);
+      expect(scrub(undefined)).toBe(undefined);
+    });
+
+    it('should handle numbers and booleans', () => {
+      expect(scrub(42)).toBe(42);
+      expect(scrub(true)).toBe(true);
+      expect(scrub(false)).toBe(false);
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle nested objects with mixed sensitive data', () => {
+      const complex = {
+        user: {
+          email: 'user@example.com',
+          password: 'secret123',
+          profile: {
+            name: 'John Doe',
+            apiKey: 'sk-1234567890abcdef1234567890abcdef',
+            preferences: {
+              theme: 'dark',
+              authToken: 'bearer-xyz789'
+            }
+          }
+        },
+        logs: ['info: user logged in', 'error: failed login for admin@company.com']
+      };
+
+      const result = scrub(complex) as any;
+      
+      expect(result.user.email).toBe('***@example.com');
+      expect(result.user.password).toBe('[REDACTED]');
+      expect(result.user.profile.name).toBe('John Doe');
+      expect(result.user.profile.apiKey).toBe('[REDACTED]');
+      expect(result.user.profile.preferences.theme).toBe('dark');
+      expect(result.user.profile.preferences.authToken).toBe('[REDACTED]');
+      expect(result.logs[0]).toBe('info: user logged in');
+      expect(result.logs[1]).toBe('error: failed login for ***@company.com');
+    });
+  });
+});

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,10 +75,20 @@ importers:
         version: 3.25.76
 
   packages/telemetry:
+    dependencies:
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.3.0)(tsx@4.20.4)
 
   tests/e2e:
     devDependencies:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -135,7 +135,7 @@ test('end-to-end request traceability with telemetry correlation', async ({ page
     release: 'local',
     route: '/api/fail',
     status: 500,
-    error_code: 'API_ERROR',
+    error_code: 'HTTP_ERROR',
     request_id: requestId,
   });
 });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -62,7 +62,7 @@ Located in `playwright.config.ts`:
 ```typescript
 export default defineConfig({
   testDir: 'tests',                    // Test files location
-  fullyParallel: true,                 // Run tests in parallel
+  fullyParallel: true,                 // Run tests in parallel (overridden by serial config)
   forbidOnly: !!process.env.CI,       // Prevent .only() in CI
   retries: process.env.CI ? 2 : 0,     // Retry failed tests in CI
   workers: process.env.CI ? 1 : undefined, // Single worker in CI
@@ -91,22 +91,31 @@ export default defineConfig({
 });
 ```
 
+**Note:** Tests in `traceability.spec.ts` are configured to run serially (`test.describe.configure({ mode: 'serial' })`) to avoid conflicts with the shared debug endpoints.
+
 ## Test Scenarios
 
-### Primary Test: Request Traceability
+### Test 1: End-to-End Request Traceability
 
 **File:** `tests/traceability.spec.ts`
 
-**Objective:** Verify end-to-end request correlation from UI action to telemetry logging
+**Objective:** Verify complete request correlation from UI action to telemetry logging
 
 **Test Flow:**
 1. **Navigate** to the web application
-2. **Verify** page loads correctly
-3. **Click** "Trigger API Error" button
+2. **Verify** page loads correctly  
+3. **Click** "Trigger API Error" button (real user interaction)
 4. **Wait** for network requests to complete
 5. **Extract** request ID from `window.__lastReqId`
 6. **Fetch** last telemetry event from debug endpoint
 7. **Assert** request IDs match between UI and telemetry
+
+**What This Tests:**
+- Real UI interaction triggers telemetry
+- Request correlation flows end-to-end
+- Web app's fetch wrapper works correctly
+- Navigator.sendBeacon/fetch fallback behavior
+- API properly stores telemetry events
 
 **Code Example:**
 ```typescript
@@ -115,7 +124,7 @@ test('end-to-end request traceability with telemetry correlation', async ({ page
   await page.goto('/');
   await expect(page.locator('h1')).toContainText('QA Instrumentation Demo');
   
-  // Trigger API error
+  // Trigger API error via real UI interaction
   const button = page.locator('button:has-text("Trigger API Error")');
   await button.click();
   await page.waitForTimeout(1000);
@@ -131,13 +140,92 @@ test('end-to-end request traceability with telemetry correlation', async ({ page
   const lastEvent = await response.json();
   expect(lastEvent).toMatchObject({
     level: 'error',
-    env: 'development',
+    env: 'development', 
     release: 'local',
     route: '/api/fail',
     status: 500,
     error_code: 'HTTP_ERROR',
     request_id: requestId,
   });
+});
+```
+
+### Test 2: API Security and Data Scrubbing Contract
+
+**File:** `tests/traceability.spec.ts`
+
+**Objective:** Validate API's telemetry scrubbing and security contract compliance
+
+**Test Flow:**
+1. **Navigate** to establish context
+2. **Send** telemetry event with realistic sensitive data to API
+3. **Verify** API accepts and processes the event (204 response)
+4. **Fetch** processed event from `/debug/telemetry/last`
+5. **Assert** sensitive data was properly scrubbed
+6. **Assert** normal data was preserved unchanged
+7. **Verify** no raw sensitive data appears anywhere in response
+
+**What This Tests:**
+- API properly scrubs sensitive data in telemetry details
+- Email addresses are redacted (***@domain format)
+- Sensitive keys (password, apiKey, authToken) are redacted
+- String truncation prevents log explosion
+- Normal data is preserved (no over-scrubbing)
+- Request correlation works for direct API calls
+- API security contract is maintained
+
+**Code Example:**
+```typescript
+test('API telemetry scrubbing and validation contract', async ({ page }) => {
+  await page.goto('/');
+  
+  const testRequestId = 'scrub-contract-' + Date.now();
+  
+  // Send realistic sensitive data that could appear in error details
+  const telemetryResponse = await page.request.post('http://localhost:3000/telemetry', {
+    headers: { 'Content-Type': 'application/json', 'x-request-id': testRequestId },
+    data: {
+      ts: Date.now(),
+      level: 'error',
+      env: 'development',
+      release: 'local',
+      route: '/api/sensitive-operation',
+      status: 400,
+      error_code: 'VALIDATION_ERROR',
+      details: {
+        userEmail: 'user@company.com',          // Email in error context
+        apiKey: 'sk-1234567890abcdef1234',      // Accidentally logged API key
+        password: 'leaked-password',             // Password in form data
+        normalField: 'safe-to-log',             // Non-sensitive data
+        longTrace: 'x'.repeat(600)              // Long stack trace
+      }
+    }
+  });
+  
+  expect(telemetryResponse.status()).toBe(204);
+  
+  // Verify scrubbing worked
+  const debugResponse = await page.request.get('http://localhost:3000/debug/telemetry/last');
+  const scrubbedEvent = await debugResponse.json();
+  
+  // Assert correlation
+  expect(scrubbedEvent.request_id).toBe(testRequestId);
+  
+  // Assert sensitive data scrubbed
+  expect(scrubbedEvent.details.userEmail).toBe('***@company.com');
+  expect(scrubbedEvent.details.apiKey).toBe('[REDACTED]');
+  expect(scrubbedEvent.details.password).toBe('[REDACTED]');
+  
+  // Assert normal data preserved
+  expect(scrubbedEvent.details.normalField).toBe('safe-to-log');
+  
+  // Assert string truncation
+  expect(scrubbedEvent.details.longTrace).toHaveLength(500);
+  
+  // Assert no leakage - negative testing
+  const eventString = JSON.stringify(scrubbedEvent);
+  expect(eventString).not.toContain('user@company.com');
+  expect(eventString).not.toContain('leaked-password');
 });
 ```
 

--- a/tests/e2e/test-results/.last-run.json
+++ b/tests/e2e/test-results/.last-run.json
@@ -1,4 +1,4 @@
 {
-  "status": "failed",
+  "status": "passed",
   "failedTests": []
 }

--- a/tests/e2e/tests/traceability.spec.ts
+++ b/tests/e2e/tests/traceability.spec.ts
@@ -50,95 +50,81 @@ test('end-to-end request traceability with telemetry correlation', async ({ page
   console.log(`✓ Telemetry event captured:`, lastEvent);
 });
 
-test('request correlation and data scrubbing via /debug/telemetry/last', async ({ page }) => {
-  // Navigate to the web app
+test('API telemetry scrubbing and validation contract', async ({ page }) => {
+  // Navigate to ensure we have proper context
   await page.goto('/');
   
-  // Verify the page loaded correctly
-  await expect(page.locator('h1')).toContainText('QA Instrumentation Demo');
+  // Test the API's telemetry scrubbing behavior directly (this is valid since it's an API contract test)
+  const testRequestId = 'scrub-contract-' + Date.now();
   
-  // Send a telemetry event with sensitive data directly to test scrubbing
-  const testRequestId = await page.evaluate(() => {
-    const requestId = 'scrub-test-' + Date.now() + '-' + Math.random().toString(36).substring(2, 8);
-    
-    // Simulate sending telemetry with sensitive details
-    fetch('/telemetry', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-request-id': requestId,
-      },
-      body: JSON.stringify({
-        ts: Date.now(),
-        level: 'error',
-        env: 'development',
-        release: 'local',
-        route: '/test/scrubbing',
-        status: 400,
-        error_code: 'VALIDATION_ERROR',
-        error: 'User data validation failed',
-        details: {
-          userEmail: 'sensitive.user@company.com',
-          apiKey: 'sk-1234567890abcdef1234567890abcdef',
-          password: 'supersecret123',
-          authToken: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
-          normalField: 'this should remain visible',
-          longString: 'a'.repeat(600), // Should be truncated
-          nestedData: {
-            email: 'nested@example.com',
-            secretKey: 'secret-value-123',
-            publicInfo: 'visible data'
-          }
-        }
-      })
-    }).catch(() => {
-      // Ignore fetch errors for this test
-    });
-    
-    return requestId;
+  // Send a telemetry event with sensitive data to verify the API contract
+  const telemetryResponse = await page.request.post('http://localhost:3000/telemetry', {
+    headers: {
+      'Content-Type': 'application/json',
+      'x-request-id': testRequestId,
+    },
+    data: {
+      ts: Date.now(),
+      level: 'error',
+      env: 'development',
+      release: 'local',
+      route: '/api/sensitive-operation',
+      status: 400,
+      error_code: 'VALIDATION_ERROR',
+      error: 'User data validation failed',
+      details: {
+        // These represent data that COULD realistically be in error details
+        userEmail: 'user@company.com',          // Email in error context
+        apiKey: 'sk-1234567890abcdef1234',      // API key accidentally logged
+        bearerToken: 'Bearer abc123def456',      // Auth token in error
+        password: 'leaked-password',             // Password in form data
+        normalField: 'safe-to-log',             // Non-sensitive data
+        errorContext: 'Form validation failed', // Normal error context
+        longTrace: 'x'.repeat(600)              // Long stack trace
+      }
+    }
   });
   
-  // Wait for telemetry to be processed
-  await page.waitForTimeout(1000);
+  // Verify telemetry was accepted
+  expect(telemetryResponse.status()).toBe(204);
   
-  // Fetch the last telemetry event using the new endpoint
-  const response = await page.request.get('http://localhost:3000/debug/telemetry/last');
-  expect(response.status()).toBe(200);
+  // Fetch the processed event to verify scrubbing worked
+  const debugResponse = await page.request.get('http://localhost:3000/debug/telemetry/last');
+  expect(debugResponse.status()).toBe(200);
   
-  const lastEvent = await response.json();
+  const scrubbedEvent = await debugResponse.json();
   
-  // 1. Assert request_id correlation (should match our test request)
-  expect(lastEvent.request_id).toBe(testRequestId);
+  // 1. Verify request correlation 
+  expect(scrubbedEvent.request_id).toBe(testRequestId);
   
-  // 2. Assert event structure
-  expect(lastEvent).toMatchObject({
+  // 2. Verify event structure is preserved
+  expect(scrubbedEvent).toMatchObject({
     level: 'error',
-    route: '/test/scrubbing',
+    route: '/api/sensitive-operation',
     status: 400,
     error_code: 'VALIDATION_ERROR',
   });
   
-  // 3. Verify details field exists and was scrubbed
-  expect(lastEvent.details).toBeDefined();
+  // 3. CRITICAL: Verify sensitive data was scrubbed
+  expect(scrubbedEvent.details.userEmail).toBe('***@company.com');      // Email redacted
+  expect(scrubbedEvent.details.apiKey).toBe('[REDACTED]');              // API key redacted  
+  expect(scrubbedEvent.details.bearerToken).toBe('[REDACTED]');         // Token redacted
+  expect(scrubbedEvent.details.password).toBe('[REDACTED]');            // Password redacted
   
-  // 4. Assert data scrubbing - emails should be redacted
-  expect(lastEvent.details.userEmail).toBe('***@company.com');
-  expect(lastEvent.details.nestedData.email).toBe('***@example.com');
+  // 4. CRITICAL: Verify safe data was preserved
+  expect(scrubbedEvent.details.normalField).toBe('safe-to-log');
+  expect(scrubbedEvent.details.errorContext).toBe('Form validation failed');
   
-  // 5. Assert sensitive keys are redacted
-  expect(lastEvent.details.apiKey).toBe('[REDACTED]');
-  expect(lastEvent.details.password).toBe('[REDACTED]');
-  expect(lastEvent.details.authToken).toBe('[REDACTED]');
-  expect(lastEvent.details.nestedData.secretKey).toBe('[REDACTED]');
+  // 5. CRITICAL: Verify string truncation works
+  expect(scrubbedEvent.details.longTrace).toHaveLength(500);
+  expect(scrubbedEvent.details.longTrace).toMatch(/\.\.\.$/);
   
-  // 6. Assert normal data is preserved
-  expect(lastEvent.details.normalField).toBe('this should remain visible');
-  expect(lastEvent.details.nestedData.publicInfo).toBe('visible data');
+  // 6. Verify no raw sensitive data leaked anywhere in the response
+  const eventString = JSON.stringify(scrubbedEvent);
+  expect(eventString).not.toContain('user@company.com');               // Original email should not appear
+  expect(eventString).not.toContain('sk-1234567890abcdef1234');        // Original API key should not appear
+  expect(eventString).not.toContain('leaked-password');                // Original password should not appear
   
-  // 7. Assert long string truncation
-  expect(lastEvent.details.longString).toHaveLength(500);
-  expect(lastEvent.details.longString).toMatch(/\.\.\.$/); // Should end with ...
-  
-  console.log(`✓ Request correlation verified with ID: ${testRequestId}`);
-  console.log(`✓ Data scrubbing verified:`, JSON.stringify(lastEvent.details, null, 2));
+  console.log(`✓ API scrubbing contract verified with ID: ${testRequestId}`);
+  console.log(`✓ Sensitive data properly redacted:`, scrubbedEvent.details);
 });

--- a/tests/e2e/tests/traceability.spec.ts
+++ b/tests/e2e/tests/traceability.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from '@playwright/test';
 
+// Configure tests to run serially to avoid debug endpoint conflicts
+test.describe.configure({ mode: 'serial' });
+
 test('end-to-end request traceability with telemetry correlation', async ({ page }) => {
   // Navigate to the web app
   await page.goto('/');
@@ -45,4 +48,97 @@ test('end-to-end request traceability with telemetry correlation', async ({ page
   
   console.log(`✓ Request correlation verified with ID: ${requestId}`);
   console.log(`✓ Telemetry event captured:`, lastEvent);
+});
+
+test('request correlation and data scrubbing via /debug/telemetry/last', async ({ page }) => {
+  // Navigate to the web app
+  await page.goto('/');
+  
+  // Verify the page loaded correctly
+  await expect(page.locator('h1')).toContainText('QA Instrumentation Demo');
+  
+  // Send a telemetry event with sensitive data directly to test scrubbing
+  const testRequestId = await page.evaluate(() => {
+    const requestId = 'scrub-test-' + Date.now() + '-' + Math.random().toString(36).substring(2, 8);
+    
+    // Simulate sending telemetry with sensitive details
+    fetch('/telemetry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-request-id': requestId,
+      },
+      body: JSON.stringify({
+        ts: Date.now(),
+        level: 'error',
+        env: 'development',
+        release: 'local',
+        route: '/test/scrubbing',
+        status: 400,
+        error_code: 'VALIDATION_ERROR',
+        error: 'User data validation failed',
+        details: {
+          userEmail: 'sensitive.user@company.com',
+          apiKey: 'sk-1234567890abcdef1234567890abcdef',
+          password: 'supersecret123',
+          authToken: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+          normalField: 'this should remain visible',
+          longString: 'a'.repeat(600), // Should be truncated
+          nestedData: {
+            email: 'nested@example.com',
+            secretKey: 'secret-value-123',
+            publicInfo: 'visible data'
+          }
+        }
+      })
+    }).catch(() => {
+      // Ignore fetch errors for this test
+    });
+    
+    return requestId;
+  });
+  
+  // Wait for telemetry to be processed
+  await page.waitForTimeout(1000);
+  
+  // Fetch the last telemetry event using the new endpoint
+  const response = await page.request.get('http://localhost:3000/debug/telemetry/last');
+  expect(response.status()).toBe(200);
+  
+  const lastEvent = await response.json();
+  
+  // 1. Assert request_id correlation (should match our test request)
+  expect(lastEvent.request_id).toBe(testRequestId);
+  
+  // 2. Assert event structure
+  expect(lastEvent).toMatchObject({
+    level: 'error',
+    route: '/test/scrubbing',
+    status: 400,
+    error_code: 'VALIDATION_ERROR',
+  });
+  
+  // 3. Verify details field exists and was scrubbed
+  expect(lastEvent.details).toBeDefined();
+  
+  // 4. Assert data scrubbing - emails should be redacted
+  expect(lastEvent.details.userEmail).toBe('***@company.com');
+  expect(lastEvent.details.nestedData.email).toBe('***@example.com');
+  
+  // 5. Assert sensitive keys are redacted
+  expect(lastEvent.details.apiKey).toBe('[REDACTED]');
+  expect(lastEvent.details.password).toBe('[REDACTED]');
+  expect(lastEvent.details.authToken).toBe('[REDACTED]');
+  expect(lastEvent.details.nestedData.secretKey).toBe('[REDACTED]');
+  
+  // 6. Assert normal data is preserved
+  expect(lastEvent.details.normalField).toBe('this should remain visible');
+  expect(lastEvent.details.nestedData.publicInfo).toBe('visible data');
+  
+  // 7. Assert long string truncation
+  expect(lastEvent.details.longString).toHaveLength(500);
+  expect(lastEvent.details.longString).toMatch(/\.\.\.$/); // Should end with ...
+  
+  console.log(`✓ Request correlation verified with ID: ${testRequestId}`);
+  console.log(`✓ Data scrubbing verified:`, JSON.stringify(lastEvent.details, null, 2));
 });

--- a/tests/e2e/tests/traceability.spec.ts
+++ b/tests/e2e/tests/traceability.spec.ts
@@ -36,7 +36,7 @@ test('end-to-end request traceability with telemetry correlation', async ({ page
     release: 'local',
     route: '/api/fail',
     status: 500,
-    error_code: 'API_ERROR',
+    error_code: 'HTTP_ERROR',
     request_id: requestId,
   });
   


### PR DESCRIPTION
feat(M3): telemetry contract + scrubber + error beacons + E2E

- Shared zod schema in `packages/telemetry` + conservative `scrub()` util.
- API `/telemetry`: validate, scrub, append to `logs/telemetry.ndjson`; echo `x-request-id`.
- Web fetch wrapper: send telemetry beacon on non-OK responses with same `request_id`.
- E2E: triggers failure, then asserts `request_id` + scrubbing via `/debug/telemetry/last`.
- Docs/status updated. Logs are gitignored.

How to run locally
- pnpm install && pnpm -r build
- Start API: pnpm -C apps/api dev
- Fast path: USE_DEV_SERVER=1 pnpm -C tests/e2e test
- Preview path: pnpm -C apps/web build && pnpm -C tests/e2e test

AI-assisted-by: Claude Code
Prompt logs: see `docs/ai/runs/*m3*`